### PR TITLE
Parallelized some things

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -7,23 +7,23 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-ark-ec = { git = "https://github.com/arkworks-rs/algebra", features = [ "parallel" ] }
-ark-ff = { git = "https://github.com/arkworks-rs/algebra", features = [ "parallel" ] }
-ark-poly = { git = "https://github.com/arkworks-rs/algebra", features = [ "parallel" ] }
-ark-std = { git = "https://github.com/arkworks-rs/utils", features = [ "parallel" ] }
-ark-groth16 = { git = "https://github.com/arkworks-rs/groth16/", features = [ "parallel", "r1cs" ] }
-ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives/", features = [ "parallel", "r1cs" ], branch = "main" }
-ark-bls12-381 = { git = "https://github.com/arkworks-rs/curves", features = [ "curve" ] }
-ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/curves" }
-ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", features = [ "curve", "r1cs" ] }
-ark-bw6-761 = { git = "https://github.com/arkworks-rs/curves" }
+ark-ec = { version = "0.2", features = [ "parallel" ] }
+ark-ff = { version = "0.2", features = [ "parallel" ] }
+ark-poly = { version = "0.2", features = [ "parallel" ] }
+ark-std = { version = "0.2", features = [ "parallel" ] }
+ark-groth16 = { version = "0.2", features = [ "parallel", "r1cs" ] }
+ark-crypto-primitives = { version = "0.2", features = [ "parallel", "r1cs" ] }
+ark-bls12-381 = { version = "0.2", features = [ "curve" ] }
+ark-ed-on-bls12-381 = "0.2"
+ark-bls12-377 = { version = "0.2", features = [ "curve", "r1cs" ] }
+ark-bw6-761 = "0.2"
 
-ark-relations = { git = "https://github.com/arkworks-rs/snark" }
-ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/" }
+ark-relations = "0.2"
+ark-r1cs-std = "0.2"
 
-digest = { version = "0.9" }
-blake2 = { version = "0.9" }
-csv = { version = "1.1.3" }
+digest = "0.9"
+blake2 = "0.9"
+csv = "1.1.3"
 
 ark-inner-products = { path = "../inner_products" }
 ark-ip-proofs = { path = "../ip_proofs" }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -21,7 +21,6 @@ ark-bw6-761 = { git = "https://github.com/arkworks-rs/curves" }
 ark-relations = { git = "https://github.com/arkworks-rs/snark" }
 ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/" }
 
-rand = { version = "0.7" }
 digest = { version = "0.9" }
 blake2 = { version = "0.9" }
 csv = { version = "1.1.3" }

--- a/benches/benches/gipa.rs
+++ b/benches/benches/gipa.rs
@@ -12,9 +12,9 @@ use ark_inner_products::{
 };
 use ark_ip_proofs::gipa::GIPA;
 
+use ark_std::rand::{rngs::StdRng, Rng, SeedableRng};
 use blake2::Blake2b;
 use digest::Digest;
-use rand::{rngs::StdRng, Rng, SeedableRng};
 
 use std::{ops::MulAssign, time::Instant};
 

--- a/benches/benches/groth16_aggregation/bench.rs
+++ b/benches/benches/groth16_aggregation/bench.rs
@@ -23,9 +23,9 @@ use ark_ip_proofs::applications::groth16_aggregation::{
     aggregate_proofs, setup_inner_product, verify_aggregate_proof,
 };
 
+use ark_std::rand::{rngs::StdRng, SeedableRng};
 use blake2::Blake2b;
 use csv::Writer;
-use rand::{rngs::StdRng, SeedableRng};
 
 use std::{io::stdout, time::Instant};
 

--- a/benches/benches/inner_products.rs
+++ b/benches/benches/inner_products.rs
@@ -3,7 +3,7 @@ use ark_ec::PairingEngine;
 use ark_ff::UniformRand;
 use ark_inner_products::{InnerProduct, MultiexponentiationInnerProduct, PairingInnerProduct};
 
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use ark_std::rand::{rngs::StdRng, Rng, SeedableRng};
 
 use std::time::Instant;
 

--- a/benches/benches/poly_commit.rs
+++ b/benches/benches/poly_commit.rs
@@ -9,8 +9,8 @@ use ark_poly::polynomial::{
     univariate::DensePolynomial as UnivariatePolynomial, Polynomial, UVPolynomial,
 };
 
+use ark_std::rand::{rngs::StdRng, SeedableRng};
 use csv::Writer;
-use rand::{rngs::StdRng, SeedableRng};
 
 use blake2::Blake2b;
 use std::{

--- a/benches/benches/tipa.rs
+++ b/benches/benches/tipa.rs
@@ -15,9 +15,9 @@ use ark_ip_proofs::tipa::{
     TIPACompatibleSetup, TIPA,
 };
 
+use ark_std::rand::{rngs::StdRng, Rng, SeedableRng};
 use blake2::Blake2b;
 use digest::Digest;
-use rand::{rngs::StdRng, Rng, SeedableRng};
 
 use std::{ops::MulAssign, time::Instant};
 

--- a/benches/examples/groth16_aggregation.rs
+++ b/benches/examples/groth16_aggregation.rs
@@ -11,8 +11,8 @@ use ark_groth16::Groth16;
 use ark_r1cs_std::{fields::fp::FpVar, prelude::*};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 
+use ark_std::rand::{rngs::StdRng, SeedableRng};
 use blake2::Blake2b;
-use rand::{rngs::StdRng, SeedableRng};
 
 #[derive(Clone)]
 struct TestCircuit {

--- a/dh_commitments/Cargo.toml
+++ b/dh_commitments/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/ark-dh-commitments/"
 [dependencies]
 ark-ff = { git = "https://github.com/arkworks-rs/algebra/", features = [ "parallel" ] }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra/", features = [ "parallel" ] }
-rand = { version = "0.7" }
+ark-std = { git = "https://github.com/arkworks-rs/utils", features = [ "parallel" ] }
 
 ark-inner-products = { path = "../inner_products" }
 

--- a/dh_commitments/Cargo.toml
+++ b/dh_commitments/Cargo.toml
@@ -14,9 +14,9 @@ repository = "https://github.com/arkworks-rs/ripp"
 documentation = "https://docs.rs/ark-dh-commitments/"
 
 [dependencies]
-ark-ff = { git = "https://github.com/arkworks-rs/algebra/", features = [ "parallel" ] }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra/", features = [ "parallel" ] }
-ark-std = { git = "https://github.com/arkworks-rs/utils", features = [ "parallel" ] }
+ark-ff = "0.2"
+ark-ec = "0.2"
+ark-std = "0.2"
 
 ark-inner-products = { path = "../inner_products" }
 
@@ -26,4 +26,4 @@ ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/curves" }
 
 [features]
 default = [ "parallel" ]
-parallel = []
+parallel = [ "ark-ff/parallel", "ark-ec/parallel" ]

--- a/dh_commitments/Cargo.toml
+++ b/dh_commitments/Cargo.toml
@@ -23,3 +23,7 @@ ark-inner-products = { path = "../inner_products" }
 [dev-dependencies]
 ark-bls12-381 = { git = "https://github.com/arkworks-rs/curves", features = [ "curve" ] }
 ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/curves" }
+
+[features]
+default = [ "parallel" ]
+parallel = []

--- a/dh_commitments/src/afgho16/mod.rs
+++ b/dh_commitments/src/afgho16/mod.rs
@@ -1,5 +1,5 @@
 use ark_ec::PairingEngine;
-use rand::Rng;
+use ark_std::rand::Rng;
 use std::marker::PhantomData;
 
 use crate::{random_generators, DoublyHomomorphicCommitment, Error};
@@ -52,7 +52,7 @@ mod tests {
     use super::*;
     use ark_bls12_381::Bls12_381;
     use ark_ff::UniformRand;
-    use rand::{rngs::StdRng, SeedableRng};
+    use ark_std::rand::{rngs::StdRng, SeedableRng};
 
     type C1 = AFGHOCommitmentG1<Bls12_381>;
     type C2 = AFGHOCommitmentG2<Bls12_381>;

--- a/dh_commitments/src/identity/mod.rs
+++ b/dh_commitments/src/identity/mod.rs
@@ -66,7 +66,7 @@ impl<T: MulAssign<F> + Clone + Default + Eq, F: Clone> MulAssign<F> for Identity
 
 impl<T, F> DoublyHomomorphicCommitment for IdentityCommitment<T, F>
 where
-    T: ToBytes + Clone + Default + Eq + Add<T, Output = T> + MulAssign<F>,
+    T: ToBytes + Clone + Default + Eq + Add<T, Output = T> + MulAssign<F> + Send + Sync,
     F: PrimeField,
 {
     type Scalar = F;

--- a/dh_commitments/src/identity/mod.rs
+++ b/dh_commitments/src/identity/mod.rs
@@ -1,5 +1,5 @@
 use ark_ff::{bytes::ToBytes, fields::PrimeField};
-use rand::Rng;
+use ark_std::rand::Rng;
 use std::{
     io::{Result as IoResult, Write},
     marker::PhantomData,

--- a/dh_commitments/src/lib.rs
+++ b/dh_commitments/src/lib.rs
@@ -22,12 +22,16 @@ pub trait DoublyHomomorphicCommitment: Clone {
         + Clone
         + Default
         + Eq
+        + Send
+        + Sync
         + Add<Self::Message, Output = Self::Message>
         + MulAssign<Self::Scalar>;
     type Key: ToBytes
         + Clone
         + Default
         + Eq
+        + Send
+        + Sync
         + Add<Self::Key, Output = Self::Key>
         + MulAssign<Self::Scalar>;
     type Output: ToBytes

--- a/dh_commitments/src/lib.rs
+++ b/dh_commitments/src/lib.rs
@@ -1,6 +1,6 @@
 use ark_ec::group::Group;
 use ark_ff::{bytes::ToBytes, fields::PrimeField};
-use rand::Rng;
+use ark_std::rand::Rng;
 use std::{
     cmp::Eq,
     error::Error as ErrorTrait,

--- a/dh_commitments/src/pedersen/mod.rs
+++ b/dh_commitments/src/pedersen/mod.rs
@@ -1,5 +1,5 @@
 use ark_ec::ProjectiveCurve;
-use rand::Rng;
+use ark_std::rand::Rng;
 use std::marker::PhantomData;
 
 use crate::{random_generators, DoublyHomomorphicCommitment, Error};
@@ -31,7 +31,7 @@ mod tests {
     use super::*;
     use ark_ed_on_bls12_381::EdwardsProjective as JubJub;
     use ark_ff::UniformRand;
-    use rand::{rngs::StdRng, SeedableRng};
+    use ark_std::rand::{rngs::StdRng, SeedableRng};
 
     type C = PedersenCommitment<JubJub>;
     const TEST_SIZE: usize = 8;

--- a/inner_products/Cargo.toml
+++ b/inner_products/Cargo.toml
@@ -16,11 +16,11 @@ documentation = "https://docs.rs/ark-inner-products/"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ark-ff = { git = "https://github.com/arkworks-rs/algebra/", features = [ "parallel" ] }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra/", features = [ "parallel" ] }
-ark-std = { git = "https://github.com/arkworks-rs/utils/", features = [ "parallel" ] }
-rayon = { version = "1" }
+ark-ff = "0.2"
+ark-ec = "0.2"
+ark-std = "0.2"
+rayon = { version = "1", optional = true }
 
 [features]
 default = [ "parallel" ]
-parallel = []
+parallel = [ "rayon", "ark-ff/parallel", "ark-ec/parallel", "ark-std/parallel" ]

--- a/inner_products/Cargo.toml
+++ b/inner_products/Cargo.toml
@@ -19,5 +19,4 @@ documentation = "https://docs.rs/ark-inner-products/"
 ark-ff = { git = "https://github.com/arkworks-rs/algebra/", features = [ "parallel" ] }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra/", features = [ "parallel" ] }
 ark-std = { git = "https://github.com/arkworks-rs/utils/", features = [ "parallel" ] }
-rand = { version = "0.7" }
 rayon = { version = "1" }

--- a/inner_products/Cargo.toml
+++ b/inner_products/Cargo.toml
@@ -21,3 +21,7 @@ ark-ec = { git = "https://github.com/arkworks-rs/algebra/", features = [ "parall
 ark-std = { git = "https://github.com/arkworks-rs/utils/", features = [ "parallel" ] }
 rand = { version = "0.7" }
 rayon = { version = "1" }
+
+[features]
+default = [ "parallel" ]
+parallel = []

--- a/inner_products/src/lib.rs
+++ b/inner_products/src/lib.rs
@@ -9,6 +9,7 @@ use std::{
     ops::{Add, Mul, MulAssign},
 };
 
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 pub type Error = Box<dyn ErrorTrait>;

--- a/inner_products/src/lib.rs
+++ b/inner_products/src/lib.rs
@@ -9,7 +9,6 @@ use std::{
     ops::{Add, Mul, MulAssign},
 };
 
-#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 pub type Error = Box<dyn ErrorTrait>;

--- a/ip_proofs/Cargo.toml
+++ b/ip_proofs/Cargo.toml
@@ -14,28 +14,28 @@ repository = "https://github.com/arkworks-rs/ripp"
 documentation = "https://docs.rs/ark-ip-proofs/"
 
 [dependencies]
-ark-ec = { git = "https://github.com/arkworks-rs/algebra", features = [ "parallel" ] }
-ark-ff = { git = "https://github.com/arkworks-rs/algebra", features = [ "parallel" ] }
-ark-poly = { git = "https://github.com/arkworks-rs/algebra", features = [ "parallel" ] }
-ark-std = { git = "https://github.com/arkworks-rs/utils", features = [ "parallel" ] }
-ark-groth16 = {git = "https://github.com/arkworks-rs/groth16/", features = [ "parallel" ] }
-digest = { version = "0.9" }
-num-traits = { version = "0.2" }
-itertools = { version = "0.10" }
-rayon = { version = "1" }
+ark-ec = "0.2"
+ark-ff = "0.2"
+ark-poly = "0.2"
+ark-std = "0.2"
+ark-groth16 = "0.2"
+digest = "0.9"
+num-traits = "0.2"
+itertools = "0.10"
+rayon = { version = "1", optional = true }
 
 ark-inner-products = { path = "../inner_products" }
 ark-dh-commitments = { path = "../dh_commitments" }
 
 [dev-dependencies]
-ark-bls12-381 = { git = "https://github.com/arkworks-rs/curves", features = [ "curve" ] }
-ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/curves" }
+ark-bls12-381 = { version = "0.2", features = [ "curve" ] }
+ark-ed-on-bls12-381 = "0.2"
 
-ark-relations = { git = "https://github.com/arkworks-rs/snark" }
-ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std" }
-blake2 = { version = "0.9" }
+ark-relations = "0.2"
+ark-r1cs-std = "0.2"
+blake2 = "0.9"
 
 [features]
 default = [ "parallel" ]
-parallel = []
+parallel = [ "rayon", "ark-ec/parallel", "ark-ff/parallel", "ark-poly/parallel", "ark-std/parallel", "ark-groth16/parallel" ]
 print-trace = [ "ark-std/print-trace" ]

--- a/ip_proofs/Cargo.toml
+++ b/ip_proofs/Cargo.toml
@@ -38,4 +38,6 @@ ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std" }
 blake2 = { version = "0.9" }
 
 [features]
+default = [ "parallel" ]
+parallel = []
 print-trace = [ "bench-utils/print-trace" ]

--- a/ip_proofs/Cargo.toml
+++ b/ip_proofs/Cargo.toml
@@ -21,7 +21,7 @@ ark-std = { git = "https://github.com/arkworks-rs/utils", features = [ "parallel
 ark-groth16 = {git = "https://github.com/arkworks-rs/groth16/", features = [ "parallel" ] }
 digest = { version = "0.9" }
 num-traits = { version = "0.2" }
-itertools = { version = "0.9" }
+itertools = { version = "0.10" }
 
 ark-inner-products = { path = "../inner_products" }
 ark-dh-commitments = { path = "../dh_commitments" }

--- a/ip_proofs/Cargo.toml
+++ b/ip_proofs/Cargo.toml
@@ -36,4 +36,4 @@ ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std" }
 blake2 = { version = "0.9" }
 
 [features]
-print-trace = [ "ark_std/print-trace" ]
+print-trace = [ "ark-std/print-trace" ]

--- a/ip_proofs/Cargo.toml
+++ b/ip_proofs/Cargo.toml
@@ -24,6 +24,7 @@ rand = { version = "0.7" }
 digest = { version = "0.9" }
 num-traits = { version = "0.2" }
 itertools = { version = "0.9" }
+rayon = "1"
 
 ark-inner-products = { path = "../inner_products" }
 ark-dh-commitments = { path = "../dh_commitments" }

--- a/ip_proofs/Cargo.toml
+++ b/ip_proofs/Cargo.toml
@@ -19,7 +19,6 @@ ark-ff = { git = "https://github.com/arkworks-rs/algebra", features = [ "paralle
 ark-poly = { git = "https://github.com/arkworks-rs/algebra", features = [ "parallel" ] }
 ark-std = { git = "https://github.com/arkworks-rs/utils", features = [ "parallel" ] }
 ark-groth16 = {git = "https://github.com/arkworks-rs/groth16/", features = [ "parallel" ] }
-bench-utils = { git = "https://github.com/arkworks-rs/utils" }
 rand = { version = "0.7" }
 digest = { version = "0.9" }
 num-traits = { version = "0.2" }
@@ -37,4 +36,4 @@ ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std" }
 blake2 = { version = "0.9" }
 
 [features]
-print-trace = [ "bench-utils/print-trace" ]
+print-trace = [ "ark_std/print-trace" ]

--- a/ip_proofs/Cargo.toml
+++ b/ip_proofs/Cargo.toml
@@ -19,7 +19,6 @@ ark-ff = { git = "https://github.com/arkworks-rs/algebra", features = [ "paralle
 ark-poly = { git = "https://github.com/arkworks-rs/algebra", features = [ "parallel" ] }
 ark-std = { git = "https://github.com/arkworks-rs/utils", features = [ "parallel" ] }
 ark-groth16 = {git = "https://github.com/arkworks-rs/groth16/", features = [ "parallel" ] }
-rand = { version = "0.7" }
 digest = { version = "0.9" }
 num-traits = { version = "0.2" }
 itertools = { version = "0.9" }

--- a/ip_proofs/src/applications/groth16_aggregation.rs
+++ b/ip_proofs/src/applications/groth16_aggregation.rs
@@ -4,8 +4,8 @@ use ark_groth16::{Proof, VerifyingKey};
 
 use std::ops::AddAssign;
 
+use ark_std::rand::Rng;
 use digest::Digest;
-use rand::Rng;
 
 use crate::{
     tipa::{

--- a/ip_proofs/src/applications/poly_commit/mod.rs
+++ b/ip_proofs/src/applications/poly_commit/mod.rs
@@ -7,8 +7,8 @@ use ark_poly::polynomial::{
 use ark_std::{end_timer, start_timer};
 use std::marker::PhantomData;
 
+use ark_std::rand::Rng;
 use digest::Digest;
-use rand::Rng;
 
 use crate::{
     tipa::{
@@ -387,8 +387,8 @@ impl<P: PairingEngine, D: Digest> UnivariatePolynomialCommitment<P, D> {
 mod tests {
     use super::*;
     use ark_bls12_381::Bls12_381;
+    use ark_std::rand::{rngs::StdRng, SeedableRng};
     use blake2::Blake2b;
-    use rand::{rngs::StdRng, SeedableRng};
 
     const BIVARIATE_X_DEGREE: usize = 7;
     const BIVARIATE_Y_DEGREE: usize = 7;

--- a/ip_proofs/src/applications/poly_commit/mod.rs
+++ b/ip_proofs/src/applications/poly_commit/mod.rs
@@ -4,7 +4,7 @@ use ark_poly::polynomial::{
     univariate::DensePolynomial as UnivariatePolynomial, Polynomial, UVPolynomial,
 };
 
-use bench_utils::{end_timer, start_timer};
+use ark_std::{end_timer, start_timer};
 use std::marker::PhantomData;
 
 use digest::Digest;

--- a/ip_proofs/src/applications/poly_commit/transparent.rs
+++ b/ip_proofs/src/applications/poly_commit/transparent.rs
@@ -4,7 +4,7 @@ use ark_poly::polynomial::{
     univariate::DensePolynomial as UnivariatePolynomial, Polynomial, UVPolynomial,
 };
 
-use bench_utils::{end_timer, start_timer};
+use ark_std::{end_timer, start_timer};
 use std::marker::PhantomData;
 
 use digest::Digest;

--- a/ip_proofs/src/applications/poly_commit/transparent.rs
+++ b/ip_proofs/src/applications/poly_commit/transparent.rs
@@ -7,8 +7,8 @@ use ark_poly::polynomial::{
 use ark_std::{end_timer, start_timer};
 use std::marker::PhantomData;
 
+use ark_std::rand::Rng;
 use digest::Digest;
-use rand::Rng;
 
 use crate::{
     gipa::GIPAProof,
@@ -322,8 +322,8 @@ mod tests {
     use ark_bls12_381::Bls12_381;
     use ark_ec::PairingEngine;
     use ark_ff::UniformRand;
+    use ark_std::rand::{rngs::StdRng, SeedableRng};
     use blake2::Blake2b;
-    use rand::{rngs::StdRng, SeedableRng};
 
     const BIVARIATE_X_DEGREE: usize = 7;
     const BIVARIATE_Y_DEGREE: usize = 7;

--- a/ip_proofs/src/gipa.rs
+++ b/ip_proofs/src/gipa.rs
@@ -1,5 +1,5 @@
 use ark_ff::{to_bytes, Field, One};
-use bench_utils::{end_timer, start_timer};
+use ark_std::{end_timer, start_timer};
 use digest::Digest;
 use rand::Rng;
 use std::{convert::TryInto, marker::PhantomData, ops::MulAssign};

--- a/ip_proofs/src/gipa.rs
+++ b/ip_proofs/src/gipa.rs
@@ -9,6 +9,7 @@ use ark_dh_commitments::DoublyHomomorphicCommitment;
 use ark_inner_products::InnerProduct;
 use ark_std::cfg_iter;
 
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 pub struct GIPA<IP, LMC, RMC, IPC, D> {
@@ -370,15 +371,19 @@ where
         assert_eq!(ck_a_agg_challenge_exponents.len(), ck_a.len());
         //TODO: Optimization: Use VariableMSM multiexponentiation
         let ck_a_base_init = mul_helper(&ck_a[0], &ck_a_agg_challenge_exponents[0]);
-        let ck_a_base = cfg_iter!(ck_a[1..])
+        let ck_a_base = ck_a[1..]
+            .iter()
             .zip(&ck_a_agg_challenge_exponents[1..])
             .map(|(g, x)| mul_helper(g, &x))
-            .reduce(|| ck_a_base_init.clone(), |sum, x| sum + x);
+            .fold(ck_a_base_init, |sum, x| sum + x);
+        //.reduce(|| ck_a_base_init.clone(), |sum, x| sum + x);
         let ck_b_base_init = mul_helper(&ck_b[0], &ck_b_agg_challenge_exponents[0]);
-        let ck_b_base = cfg_iter!(ck_b[1..])
+        let ck_b_base = ck_b[1..]
+            .iter()
             .zip(&ck_b_agg_challenge_exponents[1..])
             .map(|(g, x)| mul_helper(g, &x))
-            .reduce(|| ck_b_base_init.clone(), |sum, x| sum + x);
+            .fold(ck_b_base_init, |sum, x| sum + x);
+        //.reduce(|| ck_b_base_init.clone(), |sum, x| sum + x);
         Ok((ck_a_base, ck_b_base))
     }
 

--- a/ip_proofs/src/gipa.rs
+++ b/ip_proofs/src/gipa.rs
@@ -1,7 +1,7 @@
 use ark_ff::{to_bytes, Field, One};
+use ark_std::rand::Rng;
 use ark_std::{end_timer, start_timer};
 use digest::Digest;
-use rand::Rng;
 use std::{convert::TryInto, marker::PhantomData, ops::MulAssign};
 
 use crate::{mul_helper, Error, InnerProductArgumentError};
@@ -435,8 +435,8 @@ mod tests {
     use ark_bls12_381::Bls12_381;
     use ark_ec::PairingEngine;
     use ark_ff::UniformRand;
+    use ark_std::rand::{rngs::StdRng, SeedableRng};
     use blake2::Blake2b;
-    use rand::{rngs::StdRng, SeedableRng};
 
     use ark_dh_commitments::{
         afgho16::{AFGHOCommitmentG1, AFGHOCommitmentG2},

--- a/ip_proofs/src/tipa/mod.rs
+++ b/ip_proofs/src/tipa/mod.rs
@@ -1,10 +1,10 @@
 use ark_ec::{msm::FixedBaseMSM, PairingEngine, ProjectiveCurve};
 use ark_ff::{to_bytes, Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::polynomial::{univariate::DensePolynomial, UVPolynomial};
+use ark_std::rand::Rng;
 use ark_std::{end_timer, start_timer};
 use digest::Digest;
 use itertools::Itertools;
-use rand::Rng;
 use std::{marker::PhantomData, ops::MulAssign};
 
 use crate::{
@@ -431,8 +431,8 @@ fn polynomial_coefficients_from_transcript<F: Field>(transcript: &Vec<F>, r_shif
 mod tests {
     use super::*;
     use ark_bls12_381::Bls12_381;
+    use ark_std::rand::{rngs::StdRng, SeedableRng};
     use blake2::Blake2b;
-    use rand::{rngs::StdRng, SeedableRng};
 
     use crate::tipa::structured_scalar_message::structured_scalar_power;
     use ark_dh_commitments::{

--- a/ip_proofs/src/tipa/mod.rs
+++ b/ip_proofs/src/tipa/mod.rs
@@ -1,7 +1,7 @@
 use ark_ec::{msm::FixedBaseMSM, PairingEngine, ProjectiveCurve};
 use ark_ff::{to_bytes, Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::polynomial::{univariate::DensePolynomial, UVPolynomial};
-use bench_utils::{end_timer, start_timer};
+use ark_std::{end_timer, start_timer};
 use digest::Digest;
 use itertools::Itertools;
 use rand::Rng;

--- a/ip_proofs/src/tipa/structured_scalar_message.rs
+++ b/ip_proofs/src/tipa/structured_scalar_message.rs
@@ -1,6 +1,6 @@
 use ark_ec::{group::Group, PairingEngine, ProjectiveCurve};
 use ark_ff::{to_bytes, Field, One, PrimeField, UniformRand, Zero};
-use bench_utils::{end_timer, start_timer};
+use ark_std::{end_timer, start_timer};
 use digest::Digest;
 use rand::Rng;
 use std::{marker::PhantomData, ops::MulAssign};

--- a/ip_proofs/src/tipa/structured_scalar_message.rs
+++ b/ip_proofs/src/tipa/structured_scalar_message.rs
@@ -1,8 +1,8 @@
 use ark_ec::{group::Group, PairingEngine, ProjectiveCurve};
 use ark_ff::{to_bytes, Field, One, PrimeField, UniformRand, Zero};
+use ark_std::rand::Rng;
 use ark_std::{end_timer, start_timer};
 use digest::Digest;
-use rand::Rng;
 use std::{marker::PhantomData, ops::MulAssign};
 
 use crate::{
@@ -328,8 +328,8 @@ pub fn structured_scalar_power<F: Field>(num: usize, s: &F) -> Vec<F> {
 mod tests {
     use super::*;
     use ark_bls12_381::Bls12_381;
+    use ark_std::rand::{rngs::StdRng, SeedableRng};
     use blake2::Blake2b;
-    use rand::{rngs::StdRng, SeedableRng};
 
     use ark_dh_commitments::{
         afgho16::AFGHOCommitmentG1, identity::IdentityCommitment, pedersen::PedersenCommitment,

--- a/ip_proofs/src/tipa/structured_scalar_message.rs
+++ b/ip_proofs/src/tipa/structured_scalar_message.rs
@@ -4,8 +4,10 @@ use ark_std::cfg_iter;
 use bench_utils::{end_timer, start_timer};
 use digest::Digest;
 use rand::Rng;
-use rayon::prelude::*;
 use std::{marker::PhantomData, ops::MulAssign};
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 use crate::{
     gipa::{GIPAProof, GIPA},

--- a/ip_proofs/src/tipa/structured_scalar_message.rs
+++ b/ip_proofs/src/tipa/structured_scalar_message.rs
@@ -1,8 +1,10 @@
 use ark_ec::{group::Group, PairingEngine, ProjectiveCurve};
 use ark_ff::{to_bytes, Field, One, PrimeField, UniformRand, Zero};
+use ark_std::cfg_iter;
 use bench_utils::{end_timer, start_timer};
 use digest::Digest;
 use rand::Rng;
+use rayon::prelude::*;
 use std::{marker::PhantomData, ops::MulAssign};
 
 use crate::{
@@ -110,7 +112,7 @@ where
             product_form.push(<LMC::Scalar>::one() + &(x.inverse().unwrap() * &power_2_b));
             power_2_b *= &power_2_b.clone();
         }
-        let b_base = product_form.iter().product::<LMC::Scalar>();
+        let b_base = cfg_iter!(product_form).product::<LMC::Scalar>();
 
         // Verify base inner product commitment
         let (com_a, _, com_t) = base_com;
@@ -225,7 +227,9 @@ where
         let ck_kzg = start_timer!(|| "Prove commitment key");
         let (ck_a_final, _) = aux.ck_base;
         let transcript = aux.r_transcript;
-        let transcript_inverse = transcript.iter().map(|x| x.inverse().unwrap()).collect();
+        let transcript_inverse = cfg_iter!(transcript)
+            .map(|x| x.inverse().unwrap())
+            .collect();
 
         // KZG challenge point
         let mut counter_nonce: usize = 0;
@@ -268,7 +272,9 @@ where
             (com.0, scalar_b, com.1),
             &proof.gipa_proof,
         )?;
-        let transcript_inverse = transcript.iter().map(|x| x.inverse().unwrap()).collect();
+        let transcript_inverse = cfg_iter!(transcript)
+            .map(|x| x.inverse().unwrap())
+            .collect();
 
         let ck_a_final = &proof.final_ck;
         let ck_a_proof = &proof.final_ck_proof;
@@ -303,7 +309,7 @@ where
             product_form.push(<P::Fr>::one() + &(x.inverse().unwrap() * &power_2_b));
             power_2_b *= &power_2_b.clone();
         }
-        let b_base = product_form.iter().product::<P::Fr>();
+        let b_base = cfg_iter!(product_form).product::<P::Fr>();
 
         // Verify base inner product commitment
         let (com_a, _, com_t) = base_com;

--- a/sipp/Cargo.toml
+++ b/sipp/Cargo.toml
@@ -21,15 +21,20 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-ark-ec = { git = "https://github.com/arkworks-rs/algebra", features = [ "parallel" ] }
-ark-ff = { git = "https://github.com/arkworks-rs/algebra", features = [ "parallel" ] }
-ark-std = { git = "https://github.com/arkworks-rs/utils", features = [ "parallel" ] }
-rayon = { version = "1.0" }
-rand_chacha = { version = "0.2.1" }
-digest = { version = "0.8" }
+ark-ec = "0.2"
+ark-ff = "0.2"
+ark-std = "0.2"
+rayon = "1"
+rand_core = "0.5"
+rand_chacha = "0.2.1"
+digest = "0.8"
 
 [dev-dependencies]
 blake2 = "0.8.1"
-csv = { version = "1" }
+csv = "1"
 serde = { version = "1", features = [ "derive" ] }
-ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", features = [ "curve" ] }
+ark-bls12-377 = { version = "0.2", features = [ "curve" ] }
+
+[features]
+default = [ "parallel" ]
+parallel = [ "ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel" ]

--- a/sipp/Cargo.toml
+++ b/sipp/Cargo.toml
@@ -25,13 +25,11 @@ ark-ec = { git = "https://github.com/arkworks-rs/algebra", features = [ "paralle
 ark-ff = { git = "https://github.com/arkworks-rs/algebra", features = [ "parallel" ] }
 ark-std = { git = "https://github.com/arkworks-rs/utils", features = [ "parallel" ] }
 rayon = { version = "1.0" }
-rand_core = { version = "0.5" }
 rand_chacha = { version = "0.2.1" }
 digest = { version = "0.8" }
 
 [dev-dependencies]
 blake2 = "0.8.1"
-rand = "0.7"
 csv = { version = "1" }
 serde = { version = "1", features = [ "derive" ] }
 ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", features = [ "curve" ] }

--- a/sipp/examples/scaling-ipp.rs
+++ b/sipp/examples/scaling-ipp.rs
@@ -3,8 +3,8 @@ use ark_bls12_377::*;
 use ark_ec::ProjectiveCurve;
 use ark_ff::UniformRand;
 use ark_sipp::{rng::FiatShamirRng, SIPP};
+use ark_std::rand::seq::SliceRandom;
 use blake2::Blake2s;
-use rand::seq::SliceRandom;
 use std::time::Instant;
 
 type ExampleSIPP = SIPP<Bls12_377, Blake2s>;

--- a/sipp/src/rng.rs
+++ b/sipp/src/rng.rs
@@ -1,7 +1,7 @@
 use ark_ff::{FromBytes, ToBytes};
+use ark_std::rand::{RngCore, SeedableRng};
 use digest::{generic_array::GenericArray, Digest};
 use rand_chacha::ChaChaRng;
-use rand_core::{RngCore, SeedableRng};
 use std::marker::PhantomData;
 
 /// A `SeedableRng` that refreshes its seed by hashing together the previous seed
@@ -31,7 +31,7 @@ impl<D: Digest> RngCore for FiatShamirRng<D> {
     }
 
     #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), ark_std::rand::Error> {
         Ok(self.r.fill_bytes(dest))
     }
 }


### PR DESCRIPTION
This requires some new associated type constraints, specifically what kind of messages and keys we can use for commitments. I don't thing `Send + Sync` are at all unreasonable assumptions for a cryptographic message type or a cryptographic key type, though.

The other thing I did was use `cfg_iter!` to parallelize a bunch of functions in `ip_proofs`. This conflicts with the more direct `par_iter` notation used in the `sipp` crate. I'm not sure which one you prefer, so let me know and I'll make the change.

Lastly, this **does not compile** without the most recent changes (https://github.com/arkworks-rs/utils/pull/16) to the `utils` crate. The issue is that the `cfg_iter!` wasn't using the `rayon` iter before the new changes.